### PR TITLE
fix: add version for in-line policy

### DIFF
--- a/ext/cfndsl/role.rb
+++ b/ext/cfndsl/role.rb
@@ -37,6 +37,7 @@ def get_policy(name, statement)
   return {
     PolicyName: name,
     PolicyDocument: {
+      Version: '2012-10-17',
       Statement: statements
     }
   }

--- a/spec/role_spec.rb
+++ b/spec/role_spec.rb
@@ -45,7 +45,8 @@ context "iam_role_policies" do
           :Effect=>"Allow", 
           :Resource=>["*"], 
           :Sid=>"mypolicy"
-        }]
+        }], 
+        :Version=>"2012-10-17"
       }, 
       :PolicyName=>"my-policy"
     }])
@@ -89,7 +90,8 @@ context "iam_role_policies" do
           ],
           :Effect=>"Allow",
           :Sid=>"ec2volumes"
-        }]
+        }], 
+        :Version=>"2012-10-17"
       }, 
       :PolicyName=>"ec2-volumes"
     }])
@@ -153,7 +155,8 @@ context "iam_role_policies" do
             :Effect=>"Allow",
             :Sid=>"ec2volumes1"
           }
-        ]
+        ], 
+        :Version=>"2012-10-17"
       }, 
       :PolicyName=>"ec2-volumes"
     }])


### PR DESCRIPTION
# Overview
While working on saml federation IAM role, the policy requires policy variables such as `${redshift:DbUser}` and `${redshift:DbName}`

By default IAM policy that doesn't include version will not allow using policy variables (please refer to attached image below and [aws documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-reference-policy-checks.html#access-analyzer-reference-policy-checks-general-warning-missing-version))

<img width="787" alt="Screenshot 2023-10-16 at 6 47 32 pm" src="https://github.com/theonestack/hl-component-lib-iam/assets/26110206/8d6cad57-1451-4b65-a860-e8c8411d1f99">

Since trust policy has version set to `"Version": "2012-10-17"` ([reference](https://github.com/theonestack/hl-component-lib-iam/blob/master/ext/cfndsl/role.rb#L13)), perhaps we could also set the version to `"Version": "2012-10-17"` for iam policy

# Diff (with and without the changes)
<img width="1261" alt="Screenshot 2023-10-16 at 7 41 01 pm" src="https://github.com/theonestack/hl-component-lib-iam/assets/26110206/62fd92c6-f358-4cbf-b06f-b26af0157cec">
